### PR TITLE
feat: renamed public key header to common convention

### DIFF
--- a/pages/api/v0.1/apps/[appId]/messages.ts
+++ b/pages/api/v0.1/apps/[appId]/messages.ts
@@ -32,10 +32,10 @@ export default async function handler(
 
   switch (req.method) {
     case "GET":
-      const publicKey = req.headers.publickey;
+      const publicKey = req.headers["X-API-Key"];
 
       if (!publicKey) {
-        res.status(StatusCodes.BAD_REQUEST).end("no publicKey provided");
+        res.status(StatusCodes.BAD_REQUEST).end("no public key provided");
         return;
       }
 


### PR DESCRIPTION
It is common to use a standardized naming for custom headers starting with `X-`. Furthermore, it is common to name API key headers `X-API-Key`.
https://swagger.io/docs/specification/authentication/api-keys/