### PR TITLE
fix: change Sentry ANR threshold to 10 seconds

### DIFF
--- a/sentry.server.config.ts
+++ b/sentry.server.config.ts
@@ -14,6 +14,7 @@ Sentry.init({
 
   integrations: [
     Sentry.anrIntegration({
+      anrThreshold: sentryConfig.anrThreshold,
       captureStackTrace: true,
     }),
     Sentry.extraErrorDataIntegration(),

--- a/src/config/interfaces/SentryConfig.ts
+++ b/src/config/interfaces/SentryConfig.ts
@@ -10,4 +10,5 @@ export interface SentryConfig {
   sampleRate?: number;
   profilesSampleRate?: number;
   tracesSampleRate?: number;
+  anrThreshold?: number;
 }

--- a/src/config/loadServerConfig.ts
+++ b/src/config/loadServerConfig.ts
@@ -110,6 +110,8 @@ export function loadServerConfig(): ServerConfig {
       sampleRate: parseNumberEnvValue(env.SENTRY_SAMPLE_RATE),
       profilesSampleRate: parseNumberEnvValue(env.SENTRY_PROFILES_SAMPLE_RATE),
       tracesSampleRate: parseNumberEnvValue(env.SENTRY_TRACES_SAMPLE_RATE),
+      // Increased the default threshold to 10 seconds, due to slow startup times on Kubernetes
+      anrThreshold: parseNumberEnvValue(env.SENTRY_ANR_THRESHOLD) ?? 10_000,
     },
   };
   return config;


### PR DESCRIPTION
Closes #1495, #1497, #1502, #1507, #1516, #1523, #1530