### PR TITLE
feat: move image builds to GitHub Actions with build-time sourcemap upload

### DIFF
--- a/.github/workflows/build-and-push-image.yml
+++ b/.github/workflows/build-and-push-image.yml
@@ -1,0 +1,189 @@
+name: Build and Push Docker Image
+
+on:
+  workflow_call:
+    inputs:
+      image-name:
+        description: "Name of the Docker image (e.g., onlaunch)"
+        required: true
+        type: string
+      context-path:
+        description: "Build context path (e.g., .)"
+        required: true
+        type: string
+      dockerfile-path:
+        description: "Path to Dockerfile (e.g., ./Dockerfile)"
+        required: true
+        type: string
+      build-args:
+        description: "Build arguments as multi-line string"
+        required: false
+        type: string
+        default: ""
+    secrets:
+      DOCKERHUB_USERNAME:
+        required: true
+      DOCKERHUB_TOKEN:
+        required: true
+      SENTRY_AUTH_TOKEN:
+        required: false
+
+jobs:
+  build:
+    name: Build (${{ matrix.platform.name }})
+    runs-on: ${{ matrix.platform.runner }}
+    permissions:
+      contents: read
+      packages: write
+      attestations: write
+      id-token: write
+    timeout-minutes: 120
+    strategy:
+      fail-fast: false
+      matrix:
+        platform:
+          - name: linux/amd64
+            tag: linux-amd64
+            runner: ubuntu-24.04
+          - name: linux/arm64
+            tag: linux-arm64
+            runner: ubuntu-24.04-arm
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}-${{ inputs.image-name }}-${{ matrix.platform.name }}
+      cancel-in-progress: true
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v6
+
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
+
+      - name: Build and push by digest
+        id: build
+        uses: docker/build-push-action@v6
+        with:
+          context: ${{ inputs.context-path }}
+          file: ${{ inputs.dockerfile-path }}
+          platforms: ${{ matrix.platform.name }}
+          build-args: ${{ inputs.build-args }}
+          secrets: |
+            ${{ github.event_name != 'pull_request' && secrets.SENTRY_AUTH_TOKEN != '' && format('sentry_auth_token={0}', secrets.SENTRY_AUTH_TOKEN) || ''}}
+          cache-from: type=registry,ref=ghcr.io/${{ github.repository_owner }}/${{ inputs.image-name }}:buildcache-${{ matrix.platform.tag }}
+          cache-to: type=registry,ref=ghcr.io/${{ github.repository_owner }}/${{ inputs.image-name }}:buildcache-${{ matrix.platform.tag }},mode=max
+          tags: |
+            docker.io/kula/${{ inputs.image-name }}
+            ghcr.io/${{ github.repository_owner }}/${{ inputs.image-name }}
+          outputs: type=image,push-by-digest=true,name-canonical=true,push=${{ github.event_name != 'pull_request' }}
+
+      - name: Export digest
+        run: |
+          set -e
+          mkdir -p /tmp/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"
+          ls -la /tmp/digests
+
+      - name: Upload digest
+        uses: actions/upload-artifact@v6
+        with:
+          name: digests-${{ inputs.image-name }}-${{ matrix.platform.tag }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  merge:
+    name: Create Manifest
+    runs-on: ubuntu-24.04
+    needs: build
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+    timeout-minutes: 10
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}-merge-${{ inputs.image-name }}
+      cancel-in-progress: true
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@v7
+        with:
+          path: /tmp/digests
+          pattern: digests-${{ inputs.image-name }}-*
+          merge-multiple: true
+
+      - name: List digests
+        run: ls -la /tmp/digests
+
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Create Docker Metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            docker.io/kula/${{ inputs.image-name }}
+            ghcr.io/${{ github.repository_owner }}/${{ inputs.image-name }}
+          tags: |
+            type=raw,value=latest,enable=${{ github.event_name != 'pull_request' }}
+            type=sha
+            type=semver,pattern={{major}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}.{{minor}}.{{patch}}
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create manifest list and push
+        working-directory: /tmp/digests
+        run: |
+          # Extract all tags
+          image_tags=$(printf '%s' "$DOCKER_METADATA_OUTPUT_JSON" | jq -cr '.tags | map("-t " + .) | join(" ")')
+          echo "Creating manifest list with tags: $image_tags"
+
+          # Extract unique image names (without tags) to build digest references
+          image_names=$(printf '%s' "$DOCKER_METADATA_OUTPUT_JSON" | jq -cr '.tags | map(split(":")[0]) | unique | join(" ")')
+          echo "Image names: $image_names"
+
+          # Build digest references for all images
+          digest_refs=""
+          for image_name in $image_names; do
+            for digest_file in *; do
+              digest_refs="$digest_refs ${image_name}@sha256:${digest_file}"
+            done
+          done
+          echo "Digest references: $digest_refs"
+
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            echo "Dry run: would create manifest list with the following tags: $image_tags"
+            echo "Would use digests: $digest_refs"
+          else
+            echo "Creating manifest using buildx..."
+            docker buildx imagetools create $image_tags $digest_refs
+            # Inspect the first tag for verification
+            first_tag=$(printf '%s' "$DOCKER_METADATA_OUTPUT_JSON" | jq -cr '.tags[0]')
+            docker buildx imagetools inspect "$first_tag"
+          fi

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,53 @@
+name: Deploy
+
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - "v*"
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: Build Image
+    uses: ./.github/workflows/build-and-push-image.yml
+    with:
+      image-name: onlaunch
+      context-path: .
+      dockerfile-path: ./Dockerfile
+      build-args: |
+        GIT_SHA=${{ github.sha }}
+    secrets:
+      DOCKERHUB_USERNAME: ${{ vars.DOCKERHUB_USERNAME }}
+      DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+      SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+
+  trigger-deploy:
+    name: Trigger Infrastructure Deploy
+    needs: build
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    steps:
+      - name: Generate GitHub App Token
+        id: app_token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ vars.KULA_UPDATER_BOT_APP_ID }}
+          private-key: ${{ secrets.KULA_UPDATER_BOT_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+
+      - name: Trigger onlaunch-internal deploy
+        env:
+          GH_TOKEN: ${{ steps.app_token.outputs.token }}
+        run: |
+          curl -L \
+            -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${GH_TOKEN}" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            https://api.github.com/repos/kula-app/onlaunch-internal/dispatches \
+            -d '{"event_type":"image-built","client_payload":{"sha":"${{ github.sha }}","ref":"${{ github.ref }}"}}'
+          echo "Triggered onlaunch-internal deploy via repository_dispatch"

--- a/Dockerfile
+++ b/Dockerfile
@@ -163,6 +163,19 @@ COPY --from=build --chown=node:node /home/node/app/public ./public
 # Inject Sentry Source Maps
 RUN sentry-cli sourcemaps inject .next
 
+# Upload sourcemaps to Sentry (matched via debug IDs, no release needed at build time)
+RUN --mount=type=secret,id=sentry_auth_token \
+    if [ -f /run/secrets/sentry_auth_token ]; then \
+      echo "Uploading sourcemaps to Sentry..." && \
+      SENTRY_AUTH_TOKEN=$(cat /run/secrets/sentry_auth_token) \
+      sentry-cli sourcemaps upload \
+        --org kula-app \
+        --project onlaunch \
+        .next; \
+    else \
+      echo "Skipping sourcemap upload (no SENTRY_AUTH_TOKEN secret provided)"; \
+    fi
+
 # Select a non-root user to run the application
 USER node
 

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -2,47 +2,6 @@
 
 set -e
 
-if [ ! -z "$SENTRY_CREATE_RELEASE" ]; then
-  echo "[entrypoint.sh] Configured to create release in Sentry"
-
-  if [ ! -z "$SENTRY_RELEASE" ]; then
-    echo "[entrypoint.sh] Creating Sentry release '$SENTRY_RELEASE' ..."
-
-    if [ -z "$SENTRY_AUTH_TOKEN" ]; then
-      echo "[entrypoint.sh] Error: SENTRY_AUTH_TOKEN environment variable must be set"
-      exit 1
-    fi
-    if [ -z "$SENTRY_ORG" ]; then
-      echo "[entrypoint.sh] Error: SENTRY_ORG environment variable must be set"
-      exit 1
-    fi
-    if [ -z "$SENTRY_PROJECT" ]; then
-      echo "[entrypoint.sh] Error: SENTRY_PROJECT environment variable must be set"
-      exit 1
-    fi
-    if [ -z "$SENTRY_ENV" ]; then
-      echo "[entrypoint.sh] Error: SENTRY_ENV environment variable must be set"
-      exit 1
-    fi
-
-    echo "[entrypoint.sh] Creating Sentry Release"
-    sentry-cli login --auth-token $SENTRY_AUTH_TOKEN
-    sentry-cli releases new $SENTRY_RELEASE
-    if [ ! -z "$SENTRY_UPLOAD_SOURCEMAPS" ]; then
-      echo "[entrypoint.sh] Uploading Sourcemaps"
-      sentry-cli sourcemaps upload --release $SENTRY_RELEASE .next
-    else
-      echo "[entrypoint.sh] Skipped Uploading Sourcemaps"
-    fi
-    echo "[entrypoint.sh] Finalizing Sentry Release"
-    sentry-cli releases finalize $SENTRY_RELEASE
-
-    echo "[entrypoint.sh] Sentry release created: $SENTRY_RELEASE"
-  else
-    echo "[entrypoint.sh] Create Sentry release is enabled, but not defined in SENTRY_RELEASE"
-  fi
-fi
-
 echo "[entrypoint.sh] Setup environment variables..."
 . ./env.sh
 

--- a/next.config.js
+++ b/next.config.js
@@ -24,6 +24,11 @@ module.exports = withSentryConfig(nextConfig, {
   org: "kula-app",
   project: "onlaunch",
 
+  // Disable automatic sourcemap upload — handled by sentry-cli in Dockerfile
+  sourcemaps: {
+    disable: true,
+  },
+
   // -- SENTRY SDK OPTIONS --
   // For all available options, see:
   // https://docs.sentry.io/platforms/javascript/guides/nextjs/manual-setup/


### PR DESCRIPTION
## Summary

- Add reusable `build-and-push-image.yml` workflow for multi-arch Docker builds (amd64 + arm64) on GitHub public runners (`ubuntu-24.04` / `ubuntu-24.04-arm`)
- Add `deploy.yml` workflow that builds the image, uploads sourcemaps to Sentry during Docker build, and triggers `onlaunch-internal` deploy via `repository_dispatch`
- Update Dockerfile to use `--mount=type=secret` instead of `ARG` for `SENTRY_AUTH_TOKEN` (prevents leaking token into image layers)
- Disable webpack plugin sourcemap upload in `next.config.js` (handled by `sentry-cli` in Dockerfile)
- Remove Sentry release/upload block from `entrypoint.sh` (no longer needed at runtime)

Replaces Docker Hub automated builds with GitHub Actions. Sourcemaps are uploaded at build time via debug IDs instead of at pod startup via init container.

### Image tagging

- Push to `main`: `latest` + `sha-<commit>`
- Tag push `v1.2.3`: `1` + `1.2` + `1.2.3` + `sha-<commit>`

### Required GitHub secrets/variables

- **Secret** `DOCKERHUB_TOKEN` — Docker Hub push access
- **Secret** `SENTRY_AUTH_TOKEN` — sourcemap upload during build
- **Secret** `KULA_UPDATER_BOT_PRIVATE_KEY` — GitHub App for triggering onlaunch-internal deploys
- **Variable** `DOCKERHUB_USERNAME` — Docker Hub username
- **Variable** `KULA_UPDATER_BOT_APP_ID` — GitHub App ID

## Test plan

- [ ] Verify GitHub Actions build triggers on push to main
- [ ] Verify image appears in Docker Hub with \`latest\` + \`sha-*\` tags
- [ ] Verify sourcemaps appear in Sentry "Source Maps" section with debug IDs
- [ ] Trigger an error — verify Sentry resolves stacktrace with source context
- [ ] Push a \`v*\` tag — verify semver-tagged images are built
- [ ] Verify \`SENTRY_AUTH_TOKEN\` is NOT in any image layer (\`docker history\`)
- [ ] Disable Docker Hub automated builds after confirming GH Actions works